### PR TITLE
fix(generator): add missing !s to component template

### DIFF
--- a/generator/component/temp.component.js
+++ b/generator/component/temp.component.js
@@ -1,6 +1,6 @@
 import template from './<%= name %>.html!text';
 import controller from './<%= name %>.controller';
-import './<%= name %>.css';
+import './<%= name %>.css!';
 
 let <%= name %>Component = function(){
 	return {

--- a/generator/component/temp.spec.js
+++ b/generator/component/temp.spec.js
@@ -5,7 +5,7 @@ import 'angular-mocks';
 import <%= upCaseName %>Module from './<%= name %>'
 import <%= upCaseName %>Controller from './<%= name %>.controller';
 import <%= upCaseName %>Component from './<%= name %>.component';
-import <%= upCaseName %>Template from './<%= name %>.html';
+import <%= upCaseName %>Template from './<%= name %>.html!text';
 
 describe('<%= upCaseName %>', ()=>{
 	let $rootScope,


### PR DESCRIPTION
On the jspm branch, tests failed after generating a new component with "gulp component --name newComponent"

It looks like the issue is that the component templates were missing '!' characters on two lines. I modified the template to match the existing 'about', and 'home' components. After changing them the issue seems fixed. Let me know if the change might cause any undesirable side effects.