### PR TITLE
Resolve full, absolute paths to fix build issue

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -15,7 +15,7 @@ var root = 'client';
 var resolveTo = function(resolvePath) {
 	return function(glob) {
 		glob = glob || '';
-		return path.join(root, resolvePath, glob);
+		return path.resolve(path.join(root, resolvePath, glob));
 	}
 };
 


### PR DESCRIPTION
`gulp build` was failing, providing the following error:

```
➜  ng6-starter-jspm git:(jspm) ✗ gulp build
[06:24:53] Using gulpfile ~/Repos/ng6-starter-jspm/Gulpfile.js
[06:24:53] Starting 'build'...
[06:24:53] 'build' errored after 317 ms
[06:24:53] Error on fetch for client/app/app.js at file:///Users/eschoellhorn/Repos/ng6-starter-jspm/client/client/app/app.js
	Error: ENOENT: no such file or directory, open '/Users/eschoellhorn/Repos/ng6-starter-jspm/client/client/app/app.js'
    at Error (native)
```

It seems that JSPM was preprending the root path (perhaps from its config?) to the app's entry point. Adding `path.resolve` to the gulpfile's `resolveTo` function results in absolute paths being returned. This resolved the problem I was having. 